### PR TITLE
add node label of &usbd as zephyr_udc0

### DIFF
--- a/boards/arm/raytac_mdbt50q_rx/raytac_mdbt50q_rx.dts
+++ b/boards/arm/raytac_mdbt50q_rx/raytac_mdbt50q_rx.dts
@@ -64,7 +64,8 @@
     status = "okay";
 };
 
-&usbd {
+zephyr_udc0: &usbd {
+    compatible = "nordic,nrf-usbd";
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";


### PR DESCRIPTION
To enable ZMK studio with this dongle, the specific node label named `zephyr_udc0` seems to be required for the node `&usbd`.

Note:
- `&usbd`  is also the node label defined in `zephyr/dts/arm/nordic/nrf52840.dtsi`
- compatible below may be duplicated but didn't check
- ZMK studio successfully worked after this modification
- Build checked with ZMK v0.3