### PR TITLE
Add MDBT50Q-CX-40 dongle board support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ZMK Raytac USB Dongle Module
 
-This repository adds a ZMK board definition named `raytac_mdbt50q_rx` for the [Raytac MDBT50Q-RX](https://www.raytac.com/product/ins.php?index_id=89) USB stick, with the intention of using it as a [ZMK keyboard dongle](https://zmk.dev/docs/development/hardware-integration/dongle).
+This repository adds ZMK board definitions named `raytac_mdbt50q_rx` for the [Raytac MDBT50Q-RX](https://www.raytac.com/product/ins.php?index_id=89) USB stick and `raytac_mdbt50q_cx_40` for the [Raytac MDBT50Q-CX-40](https://www.raytac.com/product/ins.php?index_id=156) USB stick, with the intention of using them as [ZMK keyboard dongles](https://zmk.dev/docs/development/hardware-integration/dongle).
 
 ![IMG_1775](./docs/images/IMG_1775.jpeg)
 
 ## Caveat: Buy One With A UF2 Bootloader Installed
 
-The stock MDBT50Q-RX does not come with the UF2 bootloader installed—that's the bit of code that allows it to mount itself as a USB drive for flashing.
+The stock MDBT50Q-RX and MDBT50Q-CX-40 do not come with the UF2 bootloader installed—that's the bit of code that allows it to mount itself as a USB drive for flashing.
 
 But! Some versions of the dongle do exist with the UF2 bootloader pre-installed, and that's what you want buy: [Adafruit (USA)](https://www.adafruit.com/product/5199) and [Pi Hut (UK)](https://thepihut.com/products/nrf52840-usb-key-with-tinyuf2-bootloader-bluetooth-low-energy-mdbt50q-rx) sell them, and probably others if you search around. I used the one from Adafruit.
 
@@ -51,11 +51,11 @@ manifest:
 
 ## Configuring Your Dongle
 
-Follow the setup steps in the [ZMK Keyboard Dongle docs](https://zmk.dev/docs/development/hardware-integration/dongle) to configure your keyboard and dongle. When you get to the [Building the Firmware](https://zmk.dev/docs/development/hardware-integration/dongle#building-the-firmware) step, you will use `board: raytac_mdbt50q_rx` in your `build.yml` file like so:
+Follow the setup steps in the [ZMK Keyboard Dongle docs](https://zmk.dev/docs/development/hardware-integration/dongle) to configure your keyboard and dongle. When you get to the [Building the Firmware](https://zmk.dev/docs/development/hardware-integration/dongle#building-the-firmware) step, you will use `board: raytac_mdbt50q_rx` (or `board: raytac_mdbt50q_cx_40` for the CX-40 dongle) in your `build.yml` file like so:
 
 ```yaml
 include:
-  # Config settings for the dongle
+  # Config settings for the dongle (use raytac_mdbt50q_rx or raytac_mdbt50q_cx_40)
   - board: raytac_mdbt50q_rx
     shield: my_keyboard_dongle
     

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ This repository adds ZMK board definitions named `raytac_mdbt50q_rx` for the [Ra
 
 ![IMG_1775](./docs/images/IMG_1775.jpeg)
 
-## Caveat: Buy One With A UF2 Bootloader Installed
+## Caveat: Buy The RX With A UF2 Bootloader Installed
 
-The stock MDBT50Q-RX and MDBT50Q-CX-40 do not come with the UF2 bootloader installed—that's the bit of code that allows it to mount itself as a USB drive for flashing.
+The stock MDBT50Q-RX does not come with the UF2 bootloader installed—that's the bit of code that allows it to mount itself as a USB drive for flashing.
 
-But! Some versions of the dongle do exist with the UF2 bootloader pre-installed, and that's what you want buy: [Adafruit (USA)](https://www.adafruit.com/product/5199) and [Pi Hut (UK)](https://thepihut.com/products/nrf52840-usb-key-with-tinyuf2-bootloader-bluetooth-low-energy-mdbt50q-rx) sell them, and probably others if you search around. I used the one from Adafruit.
+But! Some versions of the RX dongle do exist with the UF2 bootloader pre-installed, and that's what you want to buy: [Adafruit (USA)](https://www.adafruit.com/product/5199) and [Pi Hut (UK)](https://thepihut.com/products/nrf52840-usb-key-with-tinyuf2-bootloader-bluetooth-low-energy-mdbt50q-rx) sell them, and probably others if you search around. I used the one from Adafruit.
+
+> **Note:** The MDBT50Q-CX-40 does not have a UF2 bootloader option. It ships with Nordic's built-in Open bootloader and is flashed via `nrfutil` over USB serial instead. See [Flashing The CX-40](#flashing-the-cx-40-built-in-bootloader) below.
 
 ### Update The Bootloader
 
@@ -69,6 +71,39 @@ include:
 
 ## Flashing The Raytac
 
-Entering the bootloader mode is a bit annoying. Unplug the dongle, then hold the button down while plugging it back in. 
+### Flashing The RX (UF2 Bootloader)
+
+Entering the bootloader mode is a bit annoying. Unplug the dongle, then hold the button down while plugging it back in.
 
 For some reason you *can't* double-click the reset button like on many boards.
+
+### Flashing The CX-40 (Built-In Bootloader)
+
+The CX-40 is factory-programmed with the Open bootloader from Nordic's nRF5 SDK. You'll use Nordic's `nrfutil` to create firmware packages and flash them to the device. Make sure `nrfutil` is installed before proceeding.
+
+#### Entering Bootloader Mode
+
+Unplug the dongle, then hold the push button while plugging it into USB. The push button is on the far side of the board from the USB connector. Note that the button does not face up—you'll push it from the outside in, towards the USB connector. The red LED should start a fade pattern, signalling the bootloader is running.
+
+#### Packaging and Flashing
+
+After building your ZMK firmware (which produces a `.hex` file in `build/zephyr/zephyr.hex`), package it for the bootloader:
+
+```sh
+nrfutil nrf5sdk-tools pkg generate \
+        --hw-version 52 \
+        --sd-req=0x00 \
+        --application build/zephyr/zephyr.hex \
+        --application-version 1 \
+        firmware.zip
+```
+
+Then flash it onto the board over USB serial:
+
+```sh
+nrfutil nrf5sdk-tools dfu usb-serial -pkg firmware.zip -p /dev/ttyACM0
+```
+
+> **Note:** The serial port will vary by OS. It's `/dev/ttyACM0` on Linux, something like `COMx` on Windows, and something like `/dev/cu.usbmodemXXXX` on macOS.
+
+For more information, see [Nordic Semiconductor USB DFU](https://docs.zephyrproject.org/latest/boards/raytac/mdbt50q_cx_40_dongle/doc/index.html#option-1-using-the-built-in-bootloader-only) in the Zephyr docs.

--- a/README.md
+++ b/README.md
@@ -79,31 +79,4 @@ For some reason you *can't* double-click the reset button like on many boards.
 
 ### Flashing The CX-40 (Built-In Bootloader)
 
-The CX-40 is factory-programmed with the Open bootloader from Nordic's nRF5 SDK. You'll use Nordic's `nrfutil` to create firmware packages and flash them to the device. Make sure `nrfutil` is installed before proceeding.
-
-#### Entering Bootloader Mode
-
-Unplug the dongle, then hold the push button while plugging it into USB. The push button is on the far side of the board from the USB connector. Note that the button does not face up—you'll push it from the outside in, towards the USB connector. The red LED should start a fade pattern, signalling the bootloader is running.
-
-#### Packaging and Flashing
-
-After building your ZMK firmware (which produces a `.hex` file in `build/zephyr/zephyr.hex`), package it for the bootloader:
-
-```sh
-nrfutil nrf5sdk-tools pkg generate \
-        --hw-version 52 \
-        --sd-req=0x00 \
-        --application build/zephyr/zephyr.hex \
-        --application-version 1 \
-        firmware.zip
-```
-
-Then flash it onto the board over USB serial:
-
-```sh
-nrfutil nrf5sdk-tools dfu usb-serial -pkg firmware.zip -p /dev/ttyACM0
-```
-
-> **Note:** The serial port will vary by OS. It's `/dev/ttyACM0` on Linux, something like `COMx` on Windows, and something like `/dev/cu.usbmodemXXXX` on macOS.
-
-For more information, see [Nordic Semiconductor USB DFU](https://docs.zephyrproject.org/latest/boards/raytac/mdbt50q_cx_40_dongle/doc/index.html#option-1-using-the-built-in-bootloader-only) in the Zephyr docs.
+The CX-40 does not have a UF2 bootloader. It uses Nordic's built-in Open bootloader and is flashed via `nrfutil` over USB serial. Follow the [Zephyr flashing instructions](https://docs.zephyrproject.org/latest/boards/raytac/mdbt50q_cx_40_dongle/doc/index.html#option-1-using-the-built-in-bootloader-only) for this board.

--- a/README.md
+++ b/README.md
@@ -79,4 +79,60 @@ For some reason you *can't* double-click the reset button like on many boards.
 
 ### Flashing The CX-40 (Built-In Bootloader)
 
-The CX-40 does not have a UF2 bootloader. It uses Nordic's built-in Open bootloader and is flashed via `nrfutil` over USB serial. Follow the [Zephyr flashing instructions](https://docs.zephyrproject.org/latest/boards/raytac/mdbt50q_cx_40_dongle/doc/index.html#option-1-using-the-built-in-bootloader-only) for this board.
+The CX-40 does **not** have a UF2 bootloader—there is no drag-and-drop USB drive flashing. Instead, it ships with [Nordic's Open Bootloader](https://docs.nordicsemi.com/bundle/sdk_nrf5_v17.1.0/page/sdk_app_serial_dfu_bootloader.html) (from the nRF5 SDK), which uses DFU (Device Firmware Update) over USB serial.
+
+For full reference, see the [Zephyr board documentation for the MDBT50Q-CX-40](https://docs.zephyrproject.org/latest/boards/raytac/mdbt50q_cx_40_dongle/doc/index.html#option-1-using-the-built-in-bootloader-only).
+
+#### 1. Install nrfutil
+
+Install Nordic's `nrfutil` CLI via Homebrew, then add the `nrf5sdk-tools` subcommand:
+
+```bash
+brew install --cask nrfutil
+nrfutil install nrf5sdk-tools
+```
+
+Verify it's working:
+
+```bash
+nrfutil nrf5sdk-tools --help
+```
+
+#### 2. Enter Bootloader Mode
+
+Hold the button (on the far side of the board from the USB-C connector) while plugging the dongle into USB. The red LED should start a fade pattern, which means the bootloader is running.
+
+> **Note:** The button doesn't face up—you push it from the outside in, towards the USB connector.
+
+#### 3. Find Your Serial Port (macOS)
+
+With the dongle in bootloader mode, find the serial device:
+
+```bash
+ls /dev/cu.usb*
+```
+
+You should see something like `/dev/cu.usbmodem0001` or similar. Use this path in the flash command below.
+
+#### 4. Generate DFU Package
+
+Package the hex file for the bootloader:
+
+```bash
+nrfutil nrf5sdk-tools pkg generate \
+    --hw-version 52 \
+    --sd-req=0x00 \
+    --application corne_dongle-raytac_mdbt50q_cx_40-zmk.hex \
+    --application-version 1 \
+    corne_dongle.zip
+```
+
+#### 5. Flash
+
+Flash the DFU package over USB serial (replace the port with the one you found in step 3):
+
+```bash
+nrfutil nrf5sdk-tools dfu usb-serial -pkg corne_dongle.zip -p /dev/cu.usbmodemXXXX
+```
+
+When the command finishes, the dongle resets and runs your firmware. The bootloader is not overwritten, so you can repeat this process any time you need to re-flash.

--- a/boards/arm/raytac_mdbt50q_cx_40/Kconfig
+++ b/boards/arm/raytac_mdbt50q_cx_40/Kconfig
@@ -1,0 +1,4 @@
+config BOARD_ENABLE_DCDC
+    bool "Enable DCDC mode"
+    select SOC_DCDC_NRF52X
+    default y

--- a/boards/arm/raytac_mdbt50q_cx_40/Kconfig.board
+++ b/boards/arm/raytac_mdbt50q_cx_40/Kconfig.board
@@ -1,0 +1,3 @@
+config BOARD_RAYTAC_MDBT50Q_CX_40
+    bool "Raytac MDBT50Q-CX-40"
+    depends on SOC_NRF52840_QIAA

--- a/boards/arm/raytac_mdbt50q_cx_40/Kconfig.defconfig
+++ b/boards/arm/raytac_mdbt50q_cx_40/Kconfig.defconfig
@@ -1,0 +1,19 @@
+if BOARD_RAYTAC_MDBT50Q_CX_40
+
+config BOARD
+    default "Raytac MDBT50Q-CX-40"
+
+if USB
+
+config USB_NRFX
+    default y
+
+config USB_DEVICE_STACK
+    default y
+
+endif # USB
+
+config BT_CTLR
+    default BT
+
+endif # BOARD_RAYTAC_MDBT50Q_CX_40

--- a/boards/arm/raytac_mdbt50q_cx_40/raytac_mdbt50q_cx_40.dts
+++ b/boards/arm/raytac_mdbt50q_cx_40/raytac_mdbt50q_cx_40.dts
@@ -1,0 +1,104 @@
+/*
+ * You need to update the bootloader that comes with the dongle
+ * to an UF2-enabled one, like:
+ * https://github.com/adafruit/Adafruit_nRF52_Bootloader/
+ */
+
+/dts-v1/;
+#include <nordic/nrf52840_qiaa.dtsi>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+    model = "Raytac MDBT50Q-CX-40";
+
+    chosen {
+        zephyr,code-partition = &code_partition;
+        zephyr,sram = &sram0;
+        zephyr,flash = &flash0;
+        zephyr,console = &cdc_acm_uart;
+    };
+
+    leds {
+        compatible = "gpio-leds";
+        led0: led_0 {
+            gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+            label = "Blue LED";
+        };
+    };
+
+    buttons {
+        compatible = "gpio-keys";
+        button0: button_0 {
+            gpios = <&gpio1 6 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+            label = "Push button switch";
+            zephyr,code = <INPUT_KEY_0>;
+        };
+    };
+
+    aliases {
+        sw0 = &button0;
+    };
+};
+
+&adc {
+    status = "okay";
+};
+
+&gpiote {
+    status = "okay";
+};
+
+&gpio0 {
+    status = "okay";
+};
+
+&gpio1 {
+    status = "okay";
+};
+
+zephyr_udc0: &usbd {
+    compatible = "nordic,nrf-usbd";
+    status = "okay";
+    cdc_acm_uart: cdc_acm_uart {
+        compatible = "zephyr,cdc-acm-uart";
+    };
+};
+
+/* Taken from the adafruit_itsybitsy_nrf52840.dts in Zephyr.
+ *
+ * You can compare this to the seeeduino_xiao_ble.dts they are very similar
+ */
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* To enable flashing with UF2 bootloader, we
+		 * must reserve a partition for SoftDevice.
+		 * See https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather?view=all#hathach-memory-map
+		 */
+		reserved_partition_0: partition@0 {
+			label = "SoftDevice";
+			reg = <0x000000000 DT_SIZE_K(152)>;
+		};
+		code_partition: partition@26000 {
+			label = "Application";
+			reg = <0x00026000 DT_SIZE_K(796)>;
+		};
+
+		/*
+		 * The flash starting at 0x000ed000 and ending at
+		 * 0x000f4000 is reserved for use by the application.
+		 */
+		storage_partition: partition@ed000 {
+			label = "storage";
+			reg = <0x0000ed000 DT_SIZE_K(28)>;
+		};
+
+		boot_partition: partition@f4000 {
+			label = "UF2";
+			reg = <0x000f4000 DT_SIZE_K(48)>;
+		};
+	};
+};

--- a/boards/arm/raytac_mdbt50q_cx_40/raytac_mdbt50q_cx_40.dts
+++ b/boards/arm/raytac_mdbt50q_cx_40/raytac_mdbt50q_cx_40.dts
@@ -1,7 +1,6 @@
 /*
- * You need to update the bootloader that comes with the dongle
- * to an UF2-enabled one, like:
- * https://github.com/adafruit/Adafruit_nRF52_Bootloader/
+ * The CX-40 ships with Nordic's built-in Open bootloader (nRF5 SDK).
+ * No SoftDevice or UF2 — flashing is via nrfutil DFU over USB serial.
  */
 
 /dts-v1/;
@@ -64,9 +63,13 @@ zephyr_udc0: &usbd {
     };
 };
 
-/* Taken from the adafruit_itsybitsy_nrf52840.dts in Zephyr.
+/*
+ * Flash partition table for Nordic nRF5 SDK bootloader.
  *
- * You can compare this to the seeeduino_xiao_ble.dts they are very similar
+ *   0x000000 - 0x001000  MBR (4K)
+ *   0x001000 - 0x0ed000  Application (944K)
+ *   0x0ed000 - 0x0f4000  NVS storage (28K, 7 pages)
+ *   0x0f4000 - 0x100000  Nordic bootloader + settings (48K)
  */
 &flash0 {
 	partitions {
@@ -74,30 +77,22 @@ zephyr_udc0: &usbd {
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* To enable flashing with UF2 bootloader, we
-		 * must reserve a partition for SoftDevice.
-		 * See https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather?view=all#hathach-memory-map
-		 */
-		reserved_partition_0: partition@0 {
-			label = "SoftDevice";
-			reg = <0x000000000 DT_SIZE_K(152)>;
+		mbr_partition: partition@0 {
+			label = "MBR";
+			reg = <0x00000000 DT_SIZE_K(4)>;
 		};
-		code_partition: partition@26000 {
+		code_partition: partition@1000 {
 			label = "Application";
-			reg = <0x00026000 DT_SIZE_K(796)>;
+			reg = <0x00001000 DT_SIZE_K(944)>;
 		};
 
-		/*
-		 * The flash starting at 0x000ed000 and ending at
-		 * 0x000f4000 is reserved for use by the application.
-		 */
 		storage_partition: partition@ed000 {
 			label = "storage";
-			reg = <0x0000ed000 DT_SIZE_K(28)>;
+			reg = <0x000ed000 DT_SIZE_K(28)>;
 		};
 
 		boot_partition: partition@f4000 {
-			label = "UF2";
+			label = "Nordic Bootloader";
 			reg = <0x000f4000 DT_SIZE_K(48)>;
 		};
 	};

--- a/boards/arm/raytac_mdbt50q_cx_40/raytac_mdbt50q_cx_40_defconfig
+++ b/boards/arm/raytac_mdbt50q_cx_40/raytac_mdbt50q_cx_40_defconfig
@@ -1,0 +1,36 @@
+CONFIG_SOC_SERIES_NRF52X=y
+CONFIG_SOC_NRF52840_QIAA=y
+CONFIG_BOARD_RAYTAC_MDBT50Q_CX_40=y
+
+# Follow DeviceTree partition.
+CONFIG_USE_DT_CODE_PARTITION=y
+
+# Build UF2 firmware.
+CONFIG_BUILD_OUTPUT_UF2=y
+
+# Enable MPU.
+CONFIG_ARM_MPU=y
+
+# Enable hardware stack protection.
+CONFIG_HW_STACK_PROTECTION=y
+
+# Enable basic functionality.
+CONFIG_ADC=y
+CONFIG_GPIO=y
+
+# Use NVS for settings.
+CONFIG_MPU_ALLOW_FLASH_WRITE=y
+CONFIG_NVS=y
+CONFIG_SETTINGS_NVS=y
+CONFIG_FLASH=y
+CONFIG_FLASH_PAGE_LAYOUT=y
+CONFIG_FLASH_MAP=y
+
+# Set NVS sector count to reflect storage partition size.
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=7
+
+# Use maximum Bluetooth transmit power.
+CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
+
+# Include support for Coded PHY.
+CONFIG_BT_CTLR_PHY_CODED=y

--- a/boards/arm/raytac_mdbt50q_cx_40/raytac_mdbt50q_cx_40_defconfig
+++ b/boards/arm/raytac_mdbt50q_cx_40/raytac_mdbt50q_cx_40_defconfig
@@ -5,8 +5,8 @@ CONFIG_BOARD_RAYTAC_MDBT50Q_CX_40=y
 # Follow DeviceTree partition.
 CONFIG_USE_DT_CODE_PARTITION=y
 
-# Build UF2 firmware.
-CONFIG_BUILD_OUTPUT_UF2=y
+# Build HEX firmware (no UF2 bootloader on CX-40).
+CONFIG_BUILD_OUTPUT_HEX=y
 
 # Enable MPU.
 CONFIG_ARM_MPU=y


### PR DESCRIPTION
Adds a full ZMK board definition for the Raytac MDBT50Q-CX-40 USB dongle. The CX-40 uses Nordic's built-in bootloader (not UF2 like the RX), so it needs its own board with a different flash partition layout and hex output instead of uf2.

## Changes

- Board definition under `boards/arm/raytac_mdbt50q_cx_40/` — DTS, Kconfig, defconfig
- Flash partitions sized for Nordic's bootloader (MBR + app + NVS with 7 sectors), all 4KB-aligned
- Outputs `.hex` for flashing via `nrfutil` DFU over USB serial
- README updated with CX-40 references, flashing walkthrough (nrfutil install, bootloader mode, DFU commands)

## Testing

Built and flashed onto a CX-40 dongle via `nrfutil nrf5sdk-tools dfu usb-serial`. Boots and runs ZMK.
